### PR TITLE
fix AttributeError when non-atomic model is selected

### DIFF
--- a/src/algorithms/model.py
+++ b/src/algorithms/model.py
@@ -318,7 +318,8 @@ def _get_residue_actions(
     model_spec: ModelSpec,
     chain_spec: ChainSpec,
 ) -> tuple[list[Action], int]:
-    current_chain = _get_chain(context.models, model_spec, chain_spec)
+    structure_models = context.filter_atom(context.models)
+    current_chain = _get_chain(structure_models, model_spec, chain_spec)
     if current_chain is None:
         return [], 0
     if res_index < 0 or res_index >= len(current_chain.residues):

--- a/src/algorithms/specs.py
+++ b/src/algorithms/specs.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Iterator, TYPE_CHECKING
+from typing import Iterator
 from contextlib import suppress
 from .._types import ModelType, ChainType
 


### PR DESCRIPTION
`<command> #1/A:` will raise error when `#1` is an instance of irregular model type. This PR fixes this issue